### PR TITLE
[BUGFIX] apply changes from security update

### DIFF
--- a/Configuration/Yaml/FormEditorOverrides.yaml
+++ b/Configuration/Yaml/FormEditorOverrides.yaml
@@ -108,7 +108,7 @@ TYPO3:
                     format: 'html'
                     attachUploads: false
                     translation:
-                      language: ''
+                      language: 'default'
               FormEngine:
                 label: 'Double Opt-In'
                 elements:


### PR DESCRIPTION
TYPO3-CORE-SA-2021-003 requires to define allowed values for single-select form elements